### PR TITLE
Add Streamlit crypto research dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,254 @@
+import datetime as dt
+from typing import Tuple
+
+import altair as alt
+import pandas as pd
+import streamlit as st
+
+from data_sources import (
+    DataFetchError,
+    MarketCapSnapshot,
+    fetch_ahr_timeseries,
+    fetch_btc_etf_flows,
+    fetch_btc_treasury_holdings,
+    fetch_eth_etf_flows,
+    fetch_eth_treasury_holdings,
+    fetch_global_m2,
+    fetch_market_caps,
+    fetch_mvrv_timeseries,
+    fetch_sol_treasury_holdings,
+)
+
+st.set_page_config(
+    page_title="Crypto Macro Dashboard",
+    layout="wide",
+    page_icon="📈",
+)
+
+
+st.title("📊 Crypto Macro & ETF Dashboard")
+st.markdown(
+    "该仪表盘聚合全球宏观流动性、比特币估值、ETF 资金流以及数字资产公司持仓数据，帮助快速洞察市场趋势。"
+)
+
+
+@st.cache_data(ttl=3600)
+def load_global_m2() -> pd.DataFrame:
+    return fetch_global_m2()
+
+
+@st.cache_data(ttl=1800)
+def load_market_caps() -> MarketCapSnapshot:
+    return fetch_market_caps()
+
+
+@st.cache_data(ttl=1800)
+def load_mvrv() -> pd.DataFrame:
+    start = dt.date(2013, 1, 1)
+    return fetch_mvrv_timeseries(start)
+
+
+@st.cache_data(ttl=1800)
+def load_ahr() -> pd.DataFrame:
+    return fetch_ahr_timeseries()
+
+
+@st.cache_data(ttl=900)
+def load_btc_etf_flows() -> pd.DataFrame:
+    return fetch_btc_etf_flows()
+
+
+@st.cache_data(ttl=900)
+def load_eth_etf_flows() -> pd.DataFrame:
+    return fetch_eth_etf_flows()
+
+
+@st.cache_data(ttl=3600)
+def load_btc_treasuries() -> pd.DataFrame:
+    return fetch_btc_treasury_holdings(15)
+
+
+@st.cache_data(ttl=3600)
+def load_eth_treasuries() -> pd.DataFrame:
+    return fetch_eth_treasury_holdings(15)
+
+
+@st.cache_data(ttl=3600)
+def load_sol_treasuries() -> pd.DataFrame:
+    return fetch_sol_treasury_holdings(15)
+
+
+def render_global_m2():
+    st.subheader("1. 全球 M2（广义货币）历史走势")
+    try:
+        df = load_global_m2()
+    except DataFetchError as exc:
+        st.error(f"无法获取世界银行数据：{exc}")
+        return
+
+    chart = (
+        alt.Chart(df)
+        .mark_line(point=False)
+        .encode(x="year:O", y=alt.Y("value_trillion", title="Broad Money (万亿美元)"))
+        .properties(height=380)
+    )
+    st.altair_chart(chart, use_container_width=True)
+    st.caption("数据来源：World Bank（指标 FM.LBL.BMNY.CN，单位为当前币值的广义货币）")
+
+
+def _format_number(value: float) -> str:
+    if pd.isna(value):
+        return "-"
+    if abs(value) >= 1e12:
+        return f"{value / 1e12:.2f} 万亿"
+    if abs(value) >= 1e9:
+        return f"{value / 1e9:.2f} 十亿"
+    if abs(value) >= 1e6:
+        return f"{value / 1e6:.2f} 百万"
+    return f"{value:,.0f}"
+
+
+def render_market_caps():
+    st.subheader("2. 比特币与黄金市值对比")
+    try:
+        snapshot = load_market_caps()
+    except DataFetchError as exc:
+        st.error(f"无法获取市值数据：{exc}")
+        return
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric("BTC 价格 (USD)", f"${snapshot.btc_price:,.0f}")
+    col2.metric("BTC 市值", _format_number(snapshot.btc_market_cap))
+    col3.metric("黄金市值", _format_number(snapshot.gold_market_cap))
+
+    ratio = snapshot.gold_vs_btc_upside
+    st.markdown(
+        f"**黄金市值约为比特币的 {ratio:.2f} 倍**，若比特币市值追平黄金，理论上仍有 {ratio - 1:.2f} 倍的上升空间。"
+    )
+    st.caption("BTC 市值来自 CoinGecko；黄金价格来自 goldprice.org，假设全球地上黄金约 20.5 万吨。")
+
+
+def render_btc_valuations():
+    st.subheader("3. 比特币链上估值指标")
+    col1, col2 = st.columns(2)
+
+    with col1:
+        try:
+            mvrv = load_mvrv()
+        except DataFetchError as exc:
+            st.error(f"无法获取 CoinMetrics 数据：{exc}")
+        else:
+            mvrv_chart = (
+                alt.Chart(mvrv)
+                .mark_line()
+                .encode(x="date:T", y=alt.Y("mvrv_ratio", title="MVRV Ratio"))
+                .properties(height=320)
+            )
+            st.altair_chart(mvrv_chart, use_container_width=True)
+            latest = mvrv.iloc[-1]
+            st.write(
+                f"- 最新 MVRV 为 **{latest['mvrv_ratio']:.2f}**，市场价值 / 实现价值 = {latest['cap_market_usd'] / latest['cap_realized_usd']:.2f}"
+            )
+
+    with col2:
+        try:
+            ahr = load_ahr()
+        except DataFetchError as exc:
+            st.error(f"无法获取 AHR999 指标：{exc}")
+        else:
+            base = alt.Chart(ahr).mark_line(color="#fd625e").encode(x="date:T", y="ahr:Q")
+            lines = (
+                base
+                + alt.Chart(pd.DataFrame({"value": [0.45]})).mark_rule(color="#2ab57d", strokeDash=[4, 4]).encode(y="value")
+                + alt.Chart(pd.DataFrame({"value": [1.2]})).mark_rule(color="#5156be", strokeDash=[4, 4]).encode(y="value")
+            )
+            st.altair_chart(lines.properties(height=320), use_container_width=True)
+            st.write("- AHR999 < 0.45 常被视为抄底区间；0.45-1.2 适合定投；超过 1.2 需谨慎。")
+
+    st.caption("MVRV 数据来自 CoinMetrics；AHR999 指标来自 菜籽数据。")
+
+
+def render_etf_flows():
+    st.subheader("4. BTC / ETH 现货 ETF 资金流向")
+    tabs = st.tabs(["BTC ETF", "ETH ETF"])
+
+    with tabs[0]:
+        try:
+            btc_flows = load_btc_etf_flows()
+        except DataFetchError as exc:
+            st.error(f"无法获取 BTC ETF 数据：{exc}")
+        else:
+            chart = (
+                alt.Chart(btc_flows)
+                .mark_bar(color="#fd625e")
+                .encode(x="date:T", y=alt.Y("total_flow", title="净流入 (百万美元)"))
+                .properties(height=320)
+            )
+            st.altair_chart(chart, use_container_width=True)
+            st.dataframe(btc_flows.sort_values("date", ascending=False).head(10), use_container_width=True)
+            st.caption("数据来源：Farside Investors，净流入按每日美元口径统计。")
+
+    with tabs[1]:
+        try:
+            eth_flows = load_eth_etf_flows()
+        except DataFetchError as exc:
+            st.error(f"无法获取 ETH ETF 数据：{exc}")
+        else:
+            chart = (
+                alt.Chart(eth_flows)
+                .mark_bar(color="#2ab57d")
+                .encode(x="date:T", y=alt.Y("total_flow", title="净流入 (百万美元)"))
+                .properties(height=320)
+            )
+            st.altair_chart(chart, use_container_width=True)
+            st.dataframe(eth_flows.sort_values("date", ascending=False).head(10), use_container_width=True)
+            st.caption("数据来源：Farside Investors，净流入按每日美元口径统计。")
+
+
+def render_treasury_tables():
+    st.subheader("5. 公司层面的数字资产持仓（DAT）")
+    tabs = st.tabs(["BTC", "ETH", "SOL"])
+
+    with tabs[0]:
+        try:
+            btc_df = load_btc_treasuries()
+        except DataFetchError as exc:
+            st.error(f"无法获取 BTC 公司持仓数据：{exc}")
+        else:
+            st.dataframe(btc_df, use_container_width=True, hide_index=True)
+            total = btc_df["BTC Holdings"].sum()
+            st.write(f"样本中前 15 家公司合计持有 **{total:,.0f} BTC**。")
+            st.caption("数据来源：Farside Investors Digital Asset Treasuries。")
+
+    with tabs[1]:
+        try:
+            eth_df = load_eth_treasuries()
+        except DataFetchError as exc:
+            st.error(f"无法获取 ETH 公司持仓数据：{exc}")
+        else:
+            st.dataframe(eth_df, use_container_width=True, hide_index=True)
+            total = eth_df["ETH Held"].sum()
+            st.write(f"样本中前 15 家机构合计持有 **{total:,.0f} ETH**。")
+            st.caption("数据来源：ethereumtreasuries.net。")
+
+    with tabs[2]:
+        try:
+            sol_df = load_sol_treasuries()
+        except DataFetchError as exc:
+            st.error(f"无法获取 SOL 公司持仓数据：{exc}")
+        else:
+            st.dataframe(sol_df, use_container_width=True, hide_index=True)
+            total = sol_df["SOL Held"].sum()
+            st.write(f"样本中前 15 家机构合计持有约 **{total:,.0f} SOL**。")
+            st.caption("数据来源：CoinGecko Treasuries 页面。")
+
+
+render_global_m2()
+st.divider()
+render_market_caps()
+st.divider()
+render_btc_valuations()
+st.divider()
+render_etf_flows()
+st.divider()
+render_treasury_tables()

--- a/data_sources.py
+++ b/data_sources.py
@@ -1,0 +1,380 @@
+"""Data retrieval utilities for the crypto research dashboard."""
+from __future__ import annotations
+
+import datetime as dt
+import math
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import pandas as pd
+import requests
+
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+
+HEADERS = {"User-Agent": USER_AGENT}
+
+
+class DataFetchError(RuntimeError):
+    """Raised when a remote data source cannot be retrieved."""
+
+
+@dataclass
+class MarketCapSnapshot:
+    btc_price: float
+    btc_market_cap: float
+    gold_price: float
+    gold_market_cap: float
+
+    @property
+    def btc_vs_gold_ratio(self) -> float:
+        if not self.gold_market_cap:
+            return math.nan
+        return self.btc_market_cap / self.gold_market_cap
+
+    @property
+    def gold_vs_btc_upside(self) -> float:
+        if not self.btc_market_cap:
+            return math.nan
+        return self.gold_market_cap / self.btc_market_cap
+
+
+TOTAL_ABOVE_GROUND_GOLD_TONNES = 205_000  # conservative estimate
+TONNES_TO_TROY_OZ = 32_150.7466
+
+
+def _request_json(url: str, *, headers: Optional[Dict[str, str]] = None) -> dict:
+    resp = requests.get(url, headers=headers or HEADERS, timeout=30)
+    if resp.status_code != 200:
+        raise DataFetchError(f"Failed to fetch {url} (status {resp.status_code})")
+    try:
+        return resp.json()
+    except ValueError as exc:
+        raise DataFetchError(f"Invalid JSON payload from {url}") from exc
+
+
+def _get_text(url: str, *, headers: Optional[Dict[str, str]] = None) -> str:
+    resp = requests.get(url, headers=headers or HEADERS, timeout=30)
+    if resp.status_code != 200:
+        raise DataFetchError(f"Failed to fetch {url} (status {resp.status_code})")
+    return resp.text
+
+
+def fetch_global_m2() -> pd.DataFrame:
+    """Return global broad money (M2) from the World Bank API."""
+    url = (
+        "https://api.worldbank.org/v2/country/WLD/indicator/"
+        "FM.LBL.BMNY.CN?format=json&per_page=600"
+    )
+    payload = _request_json(url)
+    records = payload[1]
+    rows: List[Dict[str, float]] = []
+    for entry in records:
+        value = entry.get("value")
+        year = entry.get("date")
+        if value is None or year is None:
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        rows.append({"year": int(year), "value": numeric})
+    df = pd.DataFrame(rows)
+    if df.empty:
+        raise DataFetchError("World Bank M2 dataset returned no usable data")
+    df.sort_values("year", inplace=True)
+    df["value_trillion"] = df["value"] / 1e12
+    return df
+
+
+def fetch_market_caps() -> MarketCapSnapshot:
+    """Return the latest BTC and gold market capitalisation figures."""
+    btc_url = (
+        "https://api.coingecko.com/api/v3/simple/price"
+        "?ids=bitcoin&vs_currencies=usd&include_market_cap=true"
+    )
+    btc_payload = _request_json(btc_url)
+    btc_data = btc_payload.get("bitcoin")
+    if not btc_data:
+        raise DataFetchError("CoinGecko response missing bitcoin data")
+    btc_price = float(btc_data["usd"])
+    btc_cap = float(btc_data["usd_market_cap"])
+
+    gold_payload = _request_json("https://data-asg.goldprice.org/dbXRates/USD")
+    items = gold_payload.get("items")
+    if not items:
+        raise DataFetchError("Gold price feed missing items list")
+    gold_price = float(items[0]["xauPrice"])  # price per troy ounce in USD
+    total_oz = TOTAL_ABOVE_GROUND_GOLD_TONNES * TONNES_TO_TROY_OZ
+    gold_cap = gold_price * total_oz
+
+    return MarketCapSnapshot(
+        btc_price=btc_price,
+        btc_market_cap=btc_cap,
+        gold_price=gold_price,
+        gold_market_cap=gold_cap,
+    )
+
+
+def _paginate_coinmetrics(base_url: str) -> Iterable[dict]:
+    next_token: Optional[str] = None
+    while True:
+        url = base_url
+        if next_token:
+            url += f"&next_page_token={next_token}"
+        payload = _request_json(url)
+        data = payload.get("data", [])
+        for row in data:
+            yield row
+        next_token = payload.get("next_page_token")
+        if not next_token:
+            break
+
+
+def fetch_mvrv_timeseries(start: dt.date) -> pd.DataFrame:
+    """Fetch daily MVRV ratio, market cap and realised cap from CoinMetrics."""
+    today = dt.date.today()
+    base_url = (
+        "https://community-api.coinmetrics.io/v4/timeseries/asset-metrics"
+        "?assets=btc&metrics=CapMrktCurUSD,CapRealUSD,CapMVRVCur"
+        f"&frequency=1d&start_time={start.isoformat()}&end_time={today.isoformat()}"
+    )
+    rows: List[Dict[str, object]] = []
+    for row in _paginate_coinmetrics(base_url):
+        try:
+            timestamp = dt.datetime.fromisoformat(row["time"].replace("Z", "+00:00"))
+        except (KeyError, ValueError) as exc:
+            raise DataFetchError("Invalid timestamp in CoinMetrics payload") from exc
+        rows.append(
+            {
+                "date": timestamp.date(),
+                "cap_market_usd": float(row["CapMrktCurUSD"]),
+                "cap_realized_usd": float(row["CapRealUSD"]),
+                "mvrv_ratio": float(row["CapMVRVCur"]),
+            }
+        )
+    df = pd.DataFrame(rows)
+    if df.empty:
+        raise DataFetchError("CoinMetrics returned no data for MVRV")
+    df.sort_values("date", inplace=True)
+    return df
+
+
+def fetch_ahr_timeseries() -> pd.DataFrame:
+    """Scrape the AHR999 indicator from CaiZi."""
+    url = "https://www.caizi.fun/trade/data/ahr"
+    html = _get_text(url)
+    anchor = 'name:\\"AHR999'
+    anchor_idx = html.find(anchor)
+    if anchor_idx == -1:
+        raise DataFetchError("Unable to locate AHR999 series in CaiZi page")
+
+    data_key = "data:["
+    labels_key = "labels:["
+
+    data_start = html.find(data_key, anchor_idx)
+    labels_start = html.find(labels_key, anchor_idx)
+    if data_start == -1 or labels_start == -1:
+        raise DataFetchError("Missing data or labels block for AHR999")
+
+    data_end = html.find(']', data_start)
+    labels_end = html.find(']', labels_start)
+    if data_end == -1 or labels_end == -1:
+        raise DataFetchError("Malformed AHR999 script section")
+
+    raw_values = [
+        v.strip()
+        for v in html[data_start + len(data_key) : data_end].split(',')
+        if v.strip()
+    ]
+    raw_labels = [
+        label.strip().strip('"')
+        for label in html[labels_start + len(labels_key) : labels_end].split(',')
+        if label.strip()
+    ]
+    if len(raw_values) != len(raw_labels):
+        raise DataFetchError("Mismatched label/value counts in AHR data")
+    dates = pd.to_datetime(raw_labels, format="%Y-%m-%d", errors="coerce")
+    values = [float(v) for v in raw_values]
+    df = pd.DataFrame({"date": dates, "ahr": values})
+    df.dropna(inplace=True)
+    df.sort_values("date", inplace=True)
+    return df
+
+
+def _proxied_farside_url(path: str) -> str:
+    return f"https://r.jina.ai/https://farside.co.uk/{path.strip('/')}/"
+
+
+def _parse_farside_daily_flows(text: str) -> pd.DataFrame:
+    rows: List[Tuple[str, float]] = []
+    date_pattern = re.compile(r"^\|\s*(\d{2} [A-Za-z]{3} \d{4})\s*\|")
+    for line in text.splitlines():
+        if not line.strip().startswith('|'):
+            continue
+        match = date_pattern.match(line)
+        if not match:
+            continue
+        date_str = match.group(1)
+        parts = [p.strip() for p in line.strip('|').split('|')]
+        if not parts:
+            continue
+        total_str = parts[-1]
+        value = _to_number(total_str)
+        rows.append((date_str, value))
+    df = pd.DataFrame(rows, columns=["date_str", "total_flow"])
+    if df.empty:
+        raise DataFetchError("No daily ETF flow rows found in Farside table")
+    df["date"] = pd.to_datetime(df["date_str"], format="%d %b %Y", errors="coerce")
+    df.dropna(subset=["date"], inplace=True)
+    df.sort_values("date", inplace=True)
+    df["total_flow"] = df["total_flow"].astype(float)
+    return df
+
+
+def fetch_btc_etf_flows() -> pd.DataFrame:
+    text = _get_text(_proxied_farside_url("btc"))
+    return _parse_farside_daily_flows(text)
+
+
+def fetch_eth_etf_flows() -> pd.DataFrame:
+    text = _get_text(_proxied_farside_url("eth"))
+    return _parse_farside_daily_flows(text)
+
+
+def _to_number(value: str) -> float:
+    value = value.strip()
+    if not value or value == '-':
+        return float("nan")
+    negative = value.startswith('(') and value.endswith(')')
+    cleaned = value.strip('()').replace(',', '').replace('$', '')
+    cleaned = cleaned.replace('+', '').replace('SOL', '').replace('ETH', '').replace('BTC', '')
+    cleaned = cleaned.replace('%', '')
+    multipliers = {"m": 1e6, "b": 1e9}
+    suffix = cleaned[-1].lower() if cleaned[-1].lower() in multipliers else ''
+    if suffix:
+        cleaned_num = cleaned[:-1]
+    else:
+        cleaned_num = cleaned
+    try:
+        number = float(cleaned_num)
+    except ValueError:
+        return float("nan")
+    if suffix:
+        number *= multipliers[suffix]
+    if negative:
+        number = -number
+    return number
+
+
+def fetch_btc_treasury_holdings(top_n: int = 15) -> pd.DataFrame:
+    text = _get_text(_proxied_farside_url("bitcoin-treasury-companies"))
+    rows: List[List[str]] = []
+    for line in text.splitlines():
+        if not line.startswith('|'):
+            continue
+        parts = [p.strip() for p in line.strip('|').split('|')]
+        if len(parts) < 9 or parts[0] in {"Ticker", ""}:
+            continue
+        rows.append(parts[:9])
+    if not rows:
+        raise DataFetchError("No BTC treasury rows parsed")
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "Ticker",
+            "Name",
+            "Type",
+            "Country",
+            "Currency",
+            "Price",
+            "Day Change",
+            "Market Cap (m)",
+            "BTC Holdings",
+        ],
+    )
+    df["BTC Holdings"] = df["BTC Holdings"].apply(_to_number)
+    df.sort_values("BTC Holdings", ascending=False, inplace=True)
+    return df.head(top_n)
+
+
+def fetch_eth_treasury_holdings(top_n: int = 15) -> pd.DataFrame:
+    text = _get_text("https://r.jina.ai/https://ethereumtreasuries.net/")
+    rows: List[List[str]] = []
+    for line in text.splitlines():
+        if not line.startswith('|'):
+            continue
+        parts = [p.strip() for p in line.strip('|').split('|')]
+        if len(parts) < 8 or parts[0] == "Company Name":
+            continue
+        rows.append(parts[:8])
+    if not rows:
+        raise DataFetchError("No Ethereum treasury data parsed")
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "Company",
+            "Ticker",
+            "Flag",
+            "ETH Held",
+            "Value (USD)",
+            "Last Update",
+            "Chart",
+            "Description",
+        ],
+    )
+    df["ETH Held"] = df["ETH Held"].apply(_to_number)
+    df.sort_values("ETH Held", ascending=False, inplace=True)
+    return df.head(top_n)
+
+
+def fetch_sol_treasury_holdings(top_n: int = 15) -> pd.DataFrame:
+    text = _get_text("https://r.jina.ai/https://www.coingecko.com/en/treasuries/solana")
+    rows: List[List[str]] = []
+    for line in text.splitlines():
+        if not line.startswith('|'):
+            continue
+        parts = [p.strip() for p in line.strip('|').split('|')]
+        if len(parts) < 8 or parts[0] == "Company":
+            continue
+        # Some rows include rank numbers at index 0
+        if parts[0].isdigit():
+            parts = parts[1:]
+        if len(parts) < 7:
+            continue
+        rows.append(parts[:7])
+    if not rows:
+        raise DataFetchError("No Solana treasury table detected")
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "Company",
+            "Type",
+            "Change",
+            "SOL Held",
+            "Value (USD)",
+            "Share of Supply",
+            "Links",
+        ],
+    )
+    df["SOL Held"] = df["SOL Held"].apply(_to_number)
+    df.sort_values("SOL Held", ascending=False, inplace=True)
+    return df.head(top_n)
+
+
+__all__ = [
+    "DataFetchError",
+    "MarketCapSnapshot",
+    "fetch_global_m2",
+    "fetch_market_caps",
+    "fetch_mvrv_timeseries",
+    "fetch_ahr_timeseries",
+    "fetch_btc_etf_flows",
+    "fetch_eth_etf_flows",
+    "fetch_btc_treasury_holdings",
+    "fetch_eth_treasury_holdings",
+    "fetch_sol_treasury_holdings",
+]

--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,35 @@
 3. btc 的估值指标 （比如 mvrv ratio , ahr99 ratio)
 4. btc , eth 的 etf 流入流出数据
 5. btc , eth , sol 的币股（DAT） 公司买盘
+
+---
+
+## 实现说明
+
+该仓库现在包含一个基于 Streamlit 的网页应用 `app.py`，整合了以上所列的五类数据。主要特性：
+
+- **全球广义货币（M2）**：来自世界银行 API，按年份绘制广义货币规模。
+- **比特币 vs 黄金市值**：实时获取 CoinGecko 的比特币价格与市值、goldprice 的黄金价格，并估算黄金总市值及相对估值空间。
+- **链上估值指标**：使用 CoinMetrics API 获取 BTC MVRV、Realized Cap，并抓取菜籽数据的 AHR999 指标。
+- **ETF 资金流**：抓取 Farside Investors 发布的 BTC / ETH 现货 ETF 每日净流入表格。
+- **数字资产公司持仓（DAT）**：分别整合 Farside、EthereumTreasuries.net、CoinGecko 的 BTC / ETH / SOL 公司持仓榜。
+
+所有数据请求均带缓存，默认缓存时长 15~60 分钟，以减少 API 调用并提升页面响应速度。
+
+## 本地运行
+
+1. 安装依赖：
+
+```bash
+pip install -r requirements.txt
+```
+
+2. 启动应用：
+
+```bash
+streamlit run app.py
+```
+
+Streamlit 启动后会输出访问地址（默认 `http://localhost:8501`）。如在远程环境运行，可通过端口转发或 VSCode Remote 隧道访问。
+
+> 注意：应用依赖外部公开 API，若运行环境无法联网将无法展示数据。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+altair>=5.0.0
+pandas>=2.0.0
+requests>=2.32.0
+streamlit>=1.37.0


### PR DESCRIPTION
## Summary
- create a Streamlit app that assembles macro liquidity, valuation, ETF flow and treasury dashboards for BTC, ETH and SOL
- implement reusable data source helpers to fetch and parse information from World Bank, CoinMetrics, Farside, EthereumTreasuries and CoinGecko
- document local usage in the README and declare Python dependencies in requirements.txt

## Testing
- python -m compileall app.py data_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68caccbb10b0832c990cf6713b92b1d3